### PR TITLE
RFC: detect closed port

### DIFF
--- a/src/trio_serial/abstract.py
+++ b/src/trio_serial/abstract.py
@@ -208,10 +208,7 @@ class AbstractSerialStream(Stream, ABC):
             max_bytes: Maximum number of bytes to receive.
         """
         with self._recv_conflict_detector:
-            while True:
-                buf = await self._recv(max_bytes)
-                if buf:
-                    return bytes(buf)
+            return bytes(await self._recv(max_bytes))
 
     async def send_all(self, data: ByteString) -> None:
         """


### PR DESCRIPTION
if a port disappeared and reappeared quickly, while someone was
awaiting receive_some, the receive_some loop ended as an infinite loop
consuming 100% cpu.

note: this should probably be done one level up, in `receive_some`.

i'm just throwing it out there to get some feedback. i'm not sure this is a safe way of detecting the issue.