### PR TITLE
Update __init__.py to export the main classes

### DIFF
--- a/src/trio_serial/__init__.py
+++ b/src/trio_serial/__init__.py
@@ -32,3 +32,5 @@ if os.name == "posix":
         from .posix import PosixSerialStream as SerialStream
 else:
     raise ImportError(f"Platform {os.name!r} not supported.")
+
+__all__ = ["SerialStream", "Parity", "StopBits"]


### PR DESCRIPTION
mypy / pylance was complaining that these weren't exported